### PR TITLE
fix: require complete inline delete margins

### DIFF
--- a/src/core/DiffEditorManager.ts
+++ b/src/core/DiffEditorManager.ts
@@ -850,21 +850,41 @@ export class DiffEditorManager {
     if (!querySelectorAll)
       return 0
 
-    const nodes = Array.from(
+    const viewWrappers = Array.from(
       querySelectorAll(
-        '.editor.modified .view-zones [monaco-view-zone], .editor.modified .margin-view-zones [monaco-view-zone]',
+        '.editor.modified .view-zones [monaco-view-zone]',
       ) ?? [],
+    ).filter((node): node is HTMLElement => {
+      return (
+        node instanceof HTMLElement
+        && (
+          node.matches('.view-lines.line-delete')
+          || !!node.querySelector('.view-lines.line-delete')
+        )
+      )
+    })
+    const marginIds = new Set(
+      Array.from(
+        querySelectorAll(
+          '.editor.modified .margin-view-zones [monaco-view-zone]',
+        ) ?? [],
+      )
+        .filter((node): node is HTMLElement => {
+          return (
+            node instanceof HTMLElement
+            && (
+              node.matches('.inline-deleted-margin-view-zone')
+              || !!node.querySelector('.inline-deleted-margin-view-zone')
+            )
+          )
+        })
+        .map(node => node.getAttribute('monaco-view-zone'))
+        .filter((id): id is string => !!id),
     )
 
-    return nodes.filter((node) => {
-      if (!(node instanceof HTMLElement))
-        return false
-      return (
-        node.matches('.view-lines.line-delete')
-        || !!node.querySelector('.view-lines.line-delete')
-        || node.matches('.inline-deleted-margin-view-zone')
-        || !!node.querySelector('.inline-deleted-margin-view-zone')
-      )
+    return viewWrappers.filter((node) => {
+      const id = node.getAttribute('monaco-view-zone')
+      return !!id && marginIds.has(id)
     }).length
   }
 
@@ -940,9 +960,16 @@ export class DiffEditorManager {
         marginWrapper: HTMLElement | null
       } => !!entry && Number.isFinite(entry.top))
       .sort((left, right) => left.top - right.top)
+    const nativePairsWithMargin = nativePairs
+      .filter((entry): entry is {
+        id: string
+        top: number
+        viewWrapper: HTMLElement
+        marginWrapper: HTMLElement
+      } => !!entry.marginWrapper)
 
-    if (nativePairs.length >= relevantChanges.length && relevantChanges.length > 0) {
-      const nextSignature = nativePairs
+    if (nativePairsWithMargin.length >= relevantChanges.length && relevantChanges.length > 0) {
+      const nextSignature = nativePairsWithMargin
         .slice(0, relevantChanges.length)
         .map((pair, index) => {
           const change = relevantChanges[index]
@@ -982,7 +1009,7 @@ export class DiffEditorManager {
       this.clearFallbackInlineDeletedZoneWrapperContent()
 
       relevantChanges.forEach((change, index) => {
-        const pair = nativePairs[index]
+        const pair = nativePairsWithMargin[index]
         const domNode = document.createElement('div')
         domNode.className = 'stream-monaco-fallback-inline-delete-zone'
         domNode.setAttribute('aria-hidden', 'true')
@@ -1007,15 +1034,13 @@ export class DiffEditorManager {
 
         pair.viewWrapper.append(domNode)
 
-        if (pair.marginWrapper) {
-          const marginDomNode = document.createElement('div')
-          marginDomNode.className = 'stream-monaco-fallback-inline-delete-margin'
-          marginDomNode.setAttribute('aria-hidden', 'true')
-          marginDomNode.setAttribute('data-stream-monaco-native-wrapper', 'true')
-          marginDomNode.style.height = '100%'
-          modifiedEditor.applyFontInfo?.(marginDomNode)
-          pair.marginWrapper.append(marginDomNode)
-        }
+        const marginDomNode = document.createElement('div')
+        marginDomNode.className = 'stream-monaco-fallback-inline-delete-margin'
+        marginDomNode.setAttribute('aria-hidden', 'true')
+        marginDomNode.setAttribute('data-stream-monaco-native-wrapper', 'true')
+        marginDomNode.style.height = '100%'
+        modifiedEditor.applyFontInfo?.(marginDomNode)
+        pair.marginWrapper.append(marginDomNode)
       })
 
       this.fallbackInlineDeletedZoneSignature = nextSignature || null
@@ -1150,17 +1175,23 @@ export class DiffEditorManager {
     const nativeFresh = this.hasFreshNativeDiffResult()
     const useInlineMode = this.isDiffInlineMode()
     const lineChanges = this.getEffectiveLineChanges()
+    const inlineDeleteChangeCount
+      = useInlineMode
+        ? lineChanges.filter(change => hasOriginalLines(change)).length
+        : 0
     const nativeInlineDeleteZoneCount
       = useInlineMode
         ? this.countNativeInlineDeleteZoneNodes()
         : 0
-    const hasNativeInlineDeleteZoneNodes = nativeInlineDeleteZoneCount > 0
+    const hasNativeInlineDeleteZoneNodes = inlineDeleteChangeCount > 0
+      ? nativeInlineDeleteZoneCount >= inlineDeleteChangeCount
+      : nativeInlineDeleteZoneCount > 0
     const hasNativeInlineDeleteNodes
       = useInlineMode
         && this.hasVisibleNativeInlineDeleteNodes()
     const shouldKeepInlineFallback
       = useInlineMode
-        && lineChanges.some(change => hasOriginalLines(change))
+        && inlineDeleteChangeCount > 0
         && !hasNativeInlineDeleteZoneNodes
     const useInlineStaleFallback
       = shouldKeepInlineFallback
@@ -1189,6 +1220,7 @@ export class DiffEditorManager {
       !nativeFresh && !keepNativeDecorationsWhileStale,
     )
     this.syncFullLineInlineDiffDecorations()
+    this.syncDiffLineNumberClasses(lineChanges)
 
     if (nativeFresh && !shouldKeepInlineFallback) {
       this.clearFallbackDiffDecorations()
@@ -1232,6 +1264,43 @@ export class DiffEditorManager {
       this.clearFallbackInlineDeletedZones()
   }
 
+  private syncDiffLineNumberClasses(lineChanges: monaco.editor.ILineChange[]) {
+    if (!this.diffEditorView)
+      return
+
+    const syncPane = (
+      editor: monaco.editor.IStandaloneCodeEditor,
+      side: 'original' | 'modified',
+    ) => {
+      const editorRoot = editor.getContainerDomNode?.()
+      if (!editorRoot || typeof editorRoot.querySelectorAll !== 'function')
+        return
+
+      const nodes = Array.from(editorRoot.querySelectorAll('.line-numbers'))
+      for (const node of nodes) {
+        if (!node.classList || typeof node.classList.toggle !== 'function')
+          continue
+        const lineNumber = Number.parseInt(node.textContent?.trim() || '', 10)
+        const changed = Number.isFinite(lineNumber) && lineChanges.some((change) => {
+          if (side === 'original') {
+            return hasOriginalLines(change)
+              && lineNumber >= change.originalStartLineNumber
+              && lineNumber <= change.originalEndLineNumber
+          }
+          return hasModifiedLines(change)
+            && lineNumber >= change.modifiedStartLineNumber
+            && lineNumber <= change.modifiedEndLineNumber
+        })
+
+        node.classList.toggle('line-delete', side === 'original' && changed)
+        node.classList.toggle('line-insert', side === 'modified' && changed)
+      }
+    }
+
+    syncPane(this.diffEditorView.getOriginalEditor(), 'original')
+    syncPane(this.diffEditorView.getModifiedEditor(), 'modified')
+  }
+
   private disposeDiffPresentationTracking() {
     this.clearFallbackDiffDecorations()
     if (this.diffPresentationObserver) {
@@ -1267,7 +1336,7 @@ export class DiffEditorManager {
   --stream-monaco-gutter-marker-width: 4px;
   --stream-monaco-gutter-gap: 16px;
   --stream-monaco-diff-code-gap: 2px;
-  --stream-monaco-diff-code-padding: 6px;
+  --stream-monaco-diff-code-padding: 7.8px;
   --stream-monaco-widget-shadow: var(--vscode-widget-shadow, rgb(15 23 42 / 26%));
   --stream-monaco-focus: var(--vscode-focusBorder, color-mix(in srgb, var(--stream-monaco-editor-fg) 56%, transparent));
   --stream-monaco-frame-radius: 20px;
@@ -1277,14 +1346,22 @@ export class DiffEditorManager {
   --stream-monaco-pane-divider: var(--stream-monaco-panel-border);
   --stream-monaco-line-number: color-mix(in srgb, var(--stream-monaco-editor-fg) 34%, transparent);
   --stream-monaco-line-number-active: color-mix(in srgb, var(--stream-monaco-editor-fg) 46%, transparent);
-  --stream-monaco-line-number-left: calc(
-    var(--stream-monaco-gutter-marker-width) + var(--stream-monaco-gutter-gap)
+  --stream-monaco-line-number-bg: var(--stream-monaco-editor-bg);
+  --stream-monaco-line-number-left: var(--stream-monaco-gutter-marker-width);
+  --stream-monaco-line-number-width: 15.6px;
+  --stream-monaco-line-number-padding-left: 15.6px;
+  --stream-monaco-line-number-padding-right: 7.8px;
+  --stream-monaco-line-number-box-width: calc(
+    var(--stream-monaco-line-number-padding-left) +
+      var(--stream-monaco-line-number-width) +
+      var(--stream-monaco-line-number-padding-right)
   );
-  --stream-monaco-line-number-width: 36px;
-  --stream-monaco-line-number-align: center;
+  --stream-monaco-line-number-gap-to-code: var(--stream-monaco-diff-code-gap);
+  --stream-monaco-line-number-align: right;
   --stream-monaco-original-margin-width: calc(
     var(--stream-monaco-line-number-left) +
-      var(--stream-monaco-line-number-width)
+      var(--stream-monaco-line-number-box-width)
+      + var(--stream-monaco-line-number-gap-to-code)
   );
   --stream-monaco-original-scrollable-left: var(
     --stream-monaco-original-margin-width
@@ -1294,7 +1371,8 @@ export class DiffEditorManager {
   );
   --stream-monaco-modified-margin-width: calc(
     var(--stream-monaco-line-number-left) +
-      var(--stream-monaco-line-number-width)
+      var(--stream-monaco-line-number-box-width)
+      + var(--stream-monaco-line-number-gap-to-code)
   );
   --stream-monaco-modified-scrollable-left: var(
     --stream-monaco-modified-margin-width
@@ -1524,11 +1602,11 @@ export class DiffEditorManager {
   display: none !important;
 }
 .stream-monaco-diff-root .monaco-diff-editor .gutter-insert {
-  background: var(--stream-monaco-added-gutter) !important;
+  background: var(--stream-monaco-added-gutter), var(--stream-monaco-added-line-fill) !important;
 }
 .stream-monaco-diff-root .monaco-diff-editor .gutter-delete,
 .stream-monaco-diff-root .monaco-editor .inline-deleted-margin-view-zone {
-  background: var(--stream-monaco-removed-gutter) !important;
+  background: var(--stream-monaco-removed-gutter), var(--stream-monaco-removed-line-fill) !important;
 }
 .stream-monaco-diff-root .monaco-editor .line-insert,
 .stream-monaco-diff-root .monaco-diff-editor .line-insert {
@@ -1547,7 +1625,7 @@ export class DiffEditorManager {
 .stream-monaco-diff-root .monaco-editor .view-line,
 .stream-monaco-diff-root .monaco-diff-editor .view-line {
   box-sizing: border-box;
-  padding-left: calc(var(--stream-monaco-diff-code-gap) + var(--stream-monaco-diff-code-padding)) !important;
+  padding-left: var(--stream-monaco-diff-code-padding) !important;
 }
 .stream-monaco-diff-root .monaco-editor .line-insert:not(.line-numbers),
 .stream-monaco-diff-root .monaco-diff-editor .line-insert:not(.line-numbers),
@@ -1559,8 +1637,14 @@ export class DiffEditorManager {
 .stream-monaco-diff-root .monaco-diff-editor .stream-monaco-fallback-line-delete,
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-inline-delete-line {
   box-sizing: border-box;
-  margin-left: var(--stream-monaco-diff-code-gap) !important;
-  width: calc(100% - var(--stream-monaco-diff-code-gap)) !important;
+  margin-left: 0 !important;
+  width: 100% !important;
+}
+.stream-monaco-diff-root.stream-monaco-diff-inline .monaco-diff-editor .editor.modified .view-zones .view-lines.line-delete,
+.stream-monaco-diff-root .monaco-diff-editor:not(.side-by-side) .editor.modified .view-zones .view-lines.line-delete {
+  margin-left: 0 !important;
+  width: 100% !important;
+  background: var(--stream-monaco-removed-line-fill) !important;
 }
 .stream-monaco-diff-root .monaco-editor .char-insert,
 .stream-monaco-diff-root .monaco-diff-editor .char-insert {
@@ -1603,10 +1687,14 @@ export class DiffEditorManager {
   box-shadow: none !important;
 }
 .stream-monaco-diff-root.stream-monaco-diff-native-stale .monaco-editor .line-delete.line-numbers,
-.stream-monaco-diff-root.stream-monaco-diff-native-stale .monaco-diff-editor .line-delete.line-numbers,
+.stream-monaco-diff-root.stream-monaco-diff-native-stale .monaco-diff-editor .line-delete.line-numbers {
+  background: var(--stream-monaco-removed-line-fill) !important;
+  color: var(--stream-monaco-removed-fg) !important;
+}
 .stream-monaco-diff-root.stream-monaco-diff-native-stale .monaco-editor .line-insert.line-numbers,
 .stream-monaco-diff-root.stream-monaco-diff-native-stale .monaco-diff-editor .line-insert.line-numbers {
-  color: var(--stream-monaco-line-number) !important;
+  background: var(--stream-monaco-added-line-fill) !important;
+  color: var(--stream-monaco-added-fg) !important;
 }
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-line-insert,
 .stream-monaco-diff-root .monaco-diff-editor .stream-monaco-fallback-line-insert {
@@ -1630,6 +1718,7 @@ export class DiffEditorManager {
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-inline-delete-line {
   box-sizing: border-box;
   width: 100%;
+  padding-left: var(--stream-monaco-diff-code-padding);
   overflow: hidden;
   white-space: pre;
   color: inherit;
@@ -1640,7 +1729,7 @@ export class DiffEditorManager {
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-inline-delete-margin {
   box-sizing: border-box;
   width: 100%;
-  background: var(--stream-monaco-removed-gutter);
+  background: var(--stream-monaco-removed-gutter), var(--stream-monaco-removed-line-fill);
   pointer-events: none;
 }
 .stream-monaco-diff-root.stream-monaco-diff-inline-native-ready .stream-monaco-fallback-inline-delete-zone,
@@ -1650,18 +1739,20 @@ export class DiffEditorManager {
 }
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-gutter-insert,
 .stream-monaco-diff-root .monaco-diff-editor .stream-monaco-fallback-gutter-insert {
-  background: var(--stream-monaco-added-gutter) !important;
+  background: var(--stream-monaco-added-gutter), var(--stream-monaco-added-line-fill) !important;
 }
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-gutter-delete,
 .stream-monaco-diff-root .monaco-diff-editor .stream-monaco-fallback-gutter-delete {
-  background: var(--stream-monaco-removed-gutter) !important;
+  background: var(--stream-monaco-removed-gutter), var(--stream-monaco-removed-line-fill) !important;
 }
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-line-number-delete,
 .stream-monaco-diff-root .monaco-diff-editor .stream-monaco-fallback-line-number-delete {
+  background: var(--stream-monaco-removed-line-fill) !important;
   color: var(--stream-monaco-removed-fg) !important;
 }
 .stream-monaco-diff-root .monaco-editor .stream-monaco-fallback-line-number-insert,
 .stream-monaco-diff-root .monaco-diff-editor .stream-monaco-fallback-line-number-insert {
+  background: var(--stream-monaco-added-line-fill) !important;
   color: var(--stream-monaco-added-fg) !important;
 }
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-diff-editor .gutter-insert {
@@ -1670,7 +1761,8 @@ export class DiffEditorManager {
       90deg,
       var(--stream-monaco-added-fg) 0 4px,
       transparent 4px 100%
-    ) !important;
+    ),
+    var(--stream-monaco-added-line-fill) !important;
 }
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-diff-editor .gutter-delete,
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-editor .inline-deleted-margin-view-zone {
@@ -1679,18 +1771,17 @@ export class DiffEditorManager {
       90deg,
       var(--stream-monaco-removed-fg) 0 4px,
       transparent 4px 100%
-    ) !important;
+    ),
+    var(--stream-monaco-removed-line-fill) !important;
 }
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-editor .line-insert,
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-diff-editor .line-insert {
-  background:
-    color-mix(in srgb, var(--stream-monaco-added-line) 34%, transparent) !important;
+  background: var(--stream-monaco-added-line-fill) !important;
   box-shadow: none !important;
 }
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-editor .line-delete,
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-diff-editor .line-delete {
-  background:
-    color-mix(in srgb, var(--stream-monaco-removed-line) 34%, transparent) !important;
+  background: var(--stream-monaco-removed-line-fill) !important;
   box-shadow: none !important;
 }
 .stream-monaco-diff-root.stream-monaco-diff-style-bar .monaco-editor .char-insert,
@@ -1767,20 +1858,27 @@ export class DiffEditorManager {
   border-radius: 999px;
 }
 .stream-monaco-diff-root .monaco-editor .line-numbers {
+  box-sizing: content-box !important;
+  background: var(--stream-monaco-line-number-bg) !important;
   color: var(--stream-monaco-line-number) !important;
   left: var(--stream-monaco-line-number-left) !important;
   width: var(--stream-monaco-line-number-width) !important;
+  padding-left: var(--stream-monaco-line-number-padding-left) !important;
+  padding-right: var(--stream-monaco-line-number-padding-right) !important;
   text-align: var(--stream-monaco-line-number-align) !important;
+  font-variant-numeric: tabular-nums;
 }
 .stream-monaco-diff-root .monaco-editor .line-numbers.active-line-number {
   color: var(--stream-monaco-line-number-active) !important;
 }
 .stream-monaco-diff-root .monaco-editor .line-delete.line-numbers,
 .stream-monaco-diff-root .monaco-diff-editor .line-delete.line-numbers {
+  background: var(--stream-monaco-removed-line-fill) !important;
   color: var(--stream-monaco-removed-fg) !important;
 }
 .stream-monaco-diff-root .monaco-editor .line-insert.line-numbers,
 .stream-monaco-diff-root .monaco-diff-editor .line-insert.line-numbers {
+  background: var(--stream-monaco-added-line-fill) !important;
   color: var(--stream-monaco-added-fg) !important;
 }
 .stream-monaco-diff-root .monaco-diff-editor .editor.original .margin,

--- a/test/diffEditor.presentation.test.ts
+++ b/test/diffEditor.presentation.test.ts
@@ -166,7 +166,14 @@ describe('DiffEditorManager diff presentation', () => {
 
       const css = appendedStyles[0]?.textContent ?? ''
       expect(css).toContain('--stream-monaco-diff-code-gap: 2px;')
-      expect(css).toContain('--stream-monaco-diff-code-padding: 6px;')
+      expect(css).toContain('--stream-monaco-diff-code-padding: 7.8px;')
+      expect(css).toContain('--stream-monaco-line-number-left: var(--stream-monaco-gutter-marker-width);')
+      expect(css).toContain('--stream-monaco-line-number-width: 15.6px;')
+      expect(css).toContain('--stream-monaco-line-number-padding-left: 15.6px;')
+      expect(css).toContain('--stream-monaco-line-number-padding-right: 7.8px;')
+      expect(css).toContain('--stream-monaco-line-number-box-width: calc(')
+      expect(css).toContain('--stream-monaco-line-number-gap-to-code: var(--stream-monaco-diff-code-gap);')
+      expect(css).toContain('--stream-monaco-line-number-align: right;')
       expect(css).toMatch(
         /\.line-insert \{\n  background: var\(--stream-monaco-added-line-fill\) !important;\n  border: 0 !important;\n  border-radius: 0 !important;/,
       )
@@ -174,14 +181,51 @@ describe('DiffEditorManager diff presentation', () => {
         /\.line-delete \{\n  background: var\(--stream-monaco-removed-line-fill\) !important;\n  border: 0 !important;\n  border-radius: 0 !important;/,
       )
       expect(css).toMatch(
+        /\.stream-monaco-diff-root\.stream-monaco-diff-style-bar \.monaco-editor \.line-insert,[\s\S]*?background: var\(--stream-monaco-added-line-fill\) !important;/,
+      )
+      expect(css).toMatch(
+        /\.stream-monaco-diff-root\.stream-monaco-diff-style-bar \.monaco-editor \.line-delete,[\s\S]*?background: var\(--stream-monaco-removed-line-fill\) !important;/,
+      )
+      expect(css).toMatch(
+        /\.stream-monaco-diff-root\.stream-monaco-diff-style-bar \.monaco-diff-editor \.gutter-insert \{[\s\S]*?var\(--stream-monaco-added-fg\) 0 4px,[\s\S]*?\),\n    var\(--stream-monaco-added-line-fill\) !important;/,
+      )
+      expect(css).toMatch(
+        /\.stream-monaco-diff-root\.stream-monaco-diff-style-bar \.monaco-diff-editor \.gutter-delete,[\s\S]*?var\(--stream-monaco-removed-fg\) 0 4px,[\s\S]*?\),\n    var\(--stream-monaco-removed-line-fill\) !important;/,
+      )
+      expect(css).not.toContain('color-mix(in srgb, var(--stream-monaco-added-line) 34%, transparent)')
+      expect(css).not.toContain('color-mix(in srgb, var(--stream-monaco-removed-line) 34%, transparent)')
+      expect(css).toMatch(
         /\.stream-monaco-fallback-line-insert \{\n  background: var\(--stream-monaco-added-line-fill\) !important;\n  border: 0 !important;\n  border-radius: 0 !important;/,
       )
       expect(css).toMatch(
         /\.stream-monaco-fallback-inline-delete-line \{[\s\S]*border-radius: 0;\n  box-shadow: var\(--stream-monaco-removed-line-shadow\);/,
       )
-      expect(css).toContain('padding-left: calc(var(--stream-monaco-diff-code-gap) + var(--stream-monaco-diff-code-padding)) !important;')
-      expect(css).toContain('margin-left: var(--stream-monaco-diff-code-gap) !important;')
-      expect(css).toContain('width: calc(100% - var(--stream-monaco-diff-code-gap)) !important;')
+      expect(css).toContain('background: var(--stream-monaco-removed-gutter), var(--stream-monaco-removed-line-fill) !important;')
+      expect(css).toContain('background: var(--stream-monaco-added-gutter), var(--stream-monaco-added-line-fill) !important;')
+      expect(css).toContain('padding-left: var(--stream-monaco-diff-code-padding);')
+      expect(css).toContain('background: var(--stream-monaco-removed-gutter), var(--stream-monaco-removed-line-fill);')
+      expect(css).toContain('padding-left: var(--stream-monaco-diff-code-padding) !important;')
+      expect(css).toContain('margin-left: 0 !important;')
+      expect(css).toContain('width: 100% !important;')
+      expect(css).toContain('.editor.modified .view-zones .view-lines.line-delete')
+      expect(css).toContain('background: var(--stream-monaco-removed-line-fill) !important;')
+      expect(css).toContain('background: var(--stream-monaco-line-number-bg) !important;')
+      expect(css).toContain('box-sizing: content-box !important;')
+      expect(css).toContain('padding-left: var(--stream-monaco-line-number-padding-left) !important;')
+      expect(css).toContain('padding-right: var(--stream-monaco-line-number-padding-right) !important;')
+      expect(css).toContain('font-variant-numeric: tabular-nums;')
+      expect(css).toMatch(
+        /\.line-delete\.line-numbers \{\n  background: var\(--stream-monaco-removed-line-fill\) !important;\n  color: var\(--stream-monaco-removed-fg\) !important;/,
+      )
+      expect(css).toMatch(
+        /\.line-insert\.line-numbers \{\n  background: var\(--stream-monaco-added-line-fill\) !important;\n  color: var\(--stream-monaco-added-fg\) !important;/,
+      )
+      expect(css).toMatch(
+        /\.stream-monaco-fallback-line-number-delete \{\n  background: var\(--stream-monaco-removed-line-fill\) !important;\n  color: var\(--stream-monaco-removed-fg\) !important;/,
+      )
+      expect(css).toMatch(
+        /\.stream-monaco-fallback-line-number-insert \{\n  background: var\(--stream-monaco-added-line-fill\) !important;\n  color: var\(--stream-monaco-added-fg\) !important;/,
+      )
       expect(css).toMatch(
         /\.char-insert \{\n  background: var\(--stream-monaco-added-inline\) !important;\n  border: 1px solid var\(--stream-monaco-added-inline-border\) !important;\n  border-radius: 6px;/,
       )
@@ -260,6 +304,83 @@ describe('DiffEditorManager diff presentation', () => {
 
       expect(fullLineInsert.classList.contains('stream-monaco-full-line-inline-insert')).toBe(true)
       expect(narrowInsert.classList.contains('stream-monaco-full-line-inline-insert')).toBe(false)
+    }
+    finally {
+      ;(globalThis as any).HTMLElement = originalHTMLElement
+    }
+  })
+
+  it('marks changed native line number nodes from line changes', () => {
+    class FakeElement {
+      private readonly classes = new Set<string>()
+      textContent = ''
+
+      constructor(text = '') {
+        this.textContent = text
+      }
+
+      classList = {
+        toggle: (name: string, force?: boolean) => {
+          if (force)
+            this.classes.add(name)
+          else
+            this.classes.delete(name)
+          return !!force
+        },
+        contains: (name: string) => this.classes.has(name),
+      }
+    }
+
+    class FakeRoot extends FakeElement {
+      constructor(private readonly nodes: FakeElement[]) {
+        super()
+      }
+
+      querySelectorAll(selector: string) {
+        return selector === '.line-numbers' ? this.nodes : []
+      }
+    }
+
+    const originalHTMLElement = (globalThis as any).HTMLElement
+    ;(globalThis as any).HTMLElement = FakeElement
+    const manager = new DiffEditorManager(
+      { readOnly: true } as any,
+      600,
+      '600px',
+      true,
+      true,
+      32,
+      2,
+      true,
+      75,
+    )
+
+    try {
+      const originalNodes = [new FakeElement('1'), new FakeElement('2'), new FakeElement('3')]
+      const modifiedNodes = [new FakeElement('1'), new FakeElement('2'), new FakeElement('3')]
+      ;(manager as any).diffEditorView = {
+        getOriginalEditor: () => ({
+          getContainerDomNode: () => new FakeRoot(originalNodes),
+        }),
+        getModifiedEditor: () => ({
+          getContainerDomNode: () => new FakeRoot(modifiedNodes),
+        }),
+      }
+
+      ;(manager as any).syncDiffLineNumberClasses([
+        {
+          originalStartLineNumber: 2,
+          originalEndLineNumber: 2,
+          modifiedStartLineNumber: 3,
+          modifiedEndLineNumber: 3,
+          charChanges: [],
+        },
+      ])
+
+      expect(originalNodes[1].classList.contains('line-delete')).toBe(true)
+      expect(originalNodes[0].classList.contains('line-delete')).toBe(false)
+      expect(modifiedNodes[2].classList.contains('line-insert')).toBe(true)
+      expect(modifiedNodes[1].classList.contains('line-insert')).toBe(false)
     }
     finally {
       ;(globalThis as any).HTMLElement = originalHTMLElement
@@ -739,7 +860,12 @@ describe('DiffEditorManager diff presentation', () => {
     const originalDocument = (globalThis as any).document
     const originalHTMLElement = (globalThis as any).HTMLElement
     class FakeElement {
-      constructor(public className: string) {}
+      attributes = new Map<string, string>()
+
+      constructor(
+        public className: string,
+        private readonly selectorMap: Record<string, FakeElement | null> = {},
+      ) {}
 
       matches(selector: string) {
         return selector.split(',').some((entry) => {
@@ -748,8 +874,16 @@ describe('DiffEditorManager diff presentation', () => {
         })
       }
 
-      querySelector() {
-        return null
+      querySelector(selector: string) {
+        return this.selectorMap[selector] ?? null
+      }
+
+      setAttribute(name: string, value: string) {
+        this.attributes.set(name, value)
+      }
+
+      getAttribute(name: string) {
+        return this.attributes.get(name) ?? null
       }
     }
     ;(globalThis as any).HTMLElement = FakeElement
@@ -776,13 +910,23 @@ describe('DiffEditorManager diff presentation', () => {
       ;(manager as any).clearFallbackInlineDeletedZones = DiffEditorManager.prototype[
         'clearFallbackInlineDeletedZones'
       ]
+      const nativeDeleteMarker = new FakeElement('view-lines line-delete monaco-mouse-cursor-text')
+      const nativeMarginMarker = new FakeElement('inline-deleted-margin-view-zone')
+      const viewWrapper = new FakeElement('', {
+        '.view-lines.line-delete': nativeDeleteMarker,
+      })
+      viewWrapper.setAttribute('monaco-view-zone', 'native-1')
+      const marginWrapper = new FakeElement('', {
+        '.inline-deleted-margin-view-zone': nativeMarginMarker,
+      })
+      marginWrapper.setAttribute('monaco-view-zone', 'native-1')
       ;(manager as any).lastContainer = {
         classList,
         querySelectorAll(selector: string) {
           if (selector.includes('.editor.modified .view-zones [monaco-view-zone]'))
-            return [new FakeElement('view-lines line-delete monaco-mouse-cursor-text')]
+            return [viewWrapper]
           if (selector.includes('.editor.modified .margin-view-zones [monaco-view-zone]'))
-            return [new FakeElement('inline-deleted-margin-view-zone')]
+            return [marginWrapper]
           return []
         },
         querySelector: vi.fn(() => null),
@@ -828,6 +972,155 @@ describe('DiffEditorManager diff presentation', () => {
 
       expect(classList.contains('stream-monaco-diff-inline-native-ready')).toBe(true)
       expect(addedZones).toHaveLength(0)
+    }
+    finally {
+      ;(globalThis as any).document = originalDocument
+      ;(globalThis as any).HTMLElement = originalHTMLElement
+    }
+  })
+
+  it('keeps inline delete fallback active until native margin zones appear', () => {
+    const originalDocument = (globalThis as any).document
+    const originalHTMLElement = (globalThis as any).HTMLElement
+    class FakeElement {
+      attributes = new Map<string, string>()
+      className = ''
+      style: Record<string, string> = {}
+      children: any[] = []
+      textContent = ''
+
+      constructor(
+        private readonly selectorMap: Record<string, FakeElement | null> = {},
+      ) {}
+
+      matches(selector: string) {
+        return selector.split(',').some((entry) => {
+          const parts = entry.trim().split('.').filter(Boolean)
+          return parts.every(part => this.className.split(/\s+/).includes(part))
+        })
+      }
+
+      querySelector(selector: string) {
+        return this.selectorMap[selector] ?? null
+      }
+
+      append(node: any) {
+        this.children.push(node)
+      }
+
+      setAttribute(name: string, value: string) {
+        this.attributes.set(name, value)
+      }
+
+      getAttribute(name: string) {
+        return this.attributes.get(name) ?? null
+      }
+    }
+    ;(globalThis as any).HTMLElement = FakeElement
+    ;(globalThis as any).document = {
+      createElement() {
+        return new FakeElement()
+      },
+    }
+
+    try {
+      const { manager, classList } = createPresentationHarness(true)
+      const addedZones: any[] = []
+      const firstNativeDeleteMarker = new FakeElement()
+      firstNativeDeleteMarker.className = 'view-lines line-delete monaco-mouse-cursor-text'
+      const secondNativeDeleteMarker = new FakeElement()
+      secondNativeDeleteMarker.className = 'view-lines line-delete monaco-mouse-cursor-text'
+      const firstNativeMarginMarker = new FakeElement()
+      firstNativeMarginMarker.className = 'inline-deleted-margin-view-zone'
+      const firstViewWrapper = new FakeElement({
+        '.view-lines.line-delete': firstNativeDeleteMarker,
+      })
+      firstViewWrapper.setAttribute('monaco-view-zone', 'native-1')
+      const secondViewWrapper = new FakeElement({
+        '.view-lines.line-delete': secondNativeDeleteMarker,
+      })
+      secondViewWrapper.setAttribute('monaco-view-zone', 'native-2')
+      const firstMarginWrapper = new FakeElement({
+        '.inline-deleted-margin-view-zone': firstNativeMarginMarker,
+      })
+      firstMarginWrapper.setAttribute('monaco-view-zone', 'native-1')
+
+      ;(manager as any).isDiffInlineMode = () => true
+      ;(manager as any).inlineDiffStreamingPresentationActive = true
+      ;(manager as any).hasFreshNativeDiffResult = () => false
+      ;(manager as any).getEffectiveLineChanges = () => [
+        {
+          originalStartLineNumber: 1,
+          originalEndLineNumber: 1,
+          modifiedStartLineNumber: 1,
+          modifiedEndLineNumber: 0,
+          charChanges: [],
+        },
+        {
+          originalStartLineNumber: 2,
+          originalEndLineNumber: 2,
+          modifiedStartLineNumber: 1,
+          modifiedEndLineNumber: 0,
+          charChanges: [],
+        },
+      ]
+      ;(manager as any).lastContainer = {
+        classList,
+        querySelectorAll(selector: string) {
+          if (selector.includes('.editor.modified .view-zones [monaco-view-zone]'))
+            return [firstViewWrapper, secondViewWrapper]
+          if (selector.includes('.editor.modified .margin-view-zones [monaco-view-zone]'))
+            return [firstMarginWrapper]
+          return []
+        },
+        querySelector: vi.fn(() => null),
+      }
+      ;(manager as any).originalModel = {
+        getAlternativeVersionId: () => 2,
+        getValue: () => 'const first = 1\nconst second = 2',
+        getLineContent: (line: number) =>
+          ['const first = 1', 'const second = 2'][line - 1] ?? '',
+      }
+      ;(manager as any).modifiedModel = {
+        getAlternativeVersionId: () => 2,
+        getValue: () => '',
+        getLineCount: () => 1,
+      }
+      ;(manager as any).diffEditorView = {
+        getLineChanges: () => null,
+        getOriginalEditor: () => ({
+          deltaDecorations: vi.fn((_: string[], next: unknown[]) =>
+            next.map((_, index) => `original-${index}`)),
+        }),
+        getModifiedEditor: () => ({
+          deltaDecorations: vi.fn((_: string[], next: unknown[]) =>
+            next.map((_, index) => `modified-${index}`)),
+          getModel: () => (manager as any).modifiedModel,
+          getOption: () => 20,
+          applyFontInfo: vi.fn(),
+          changeViewZones(callback: (accessor: {
+            addZone: (zone: any) => string
+            removeZone: (id: string) => void
+          }) => void) {
+            callback({
+              addZone(zone) {
+                addedZones.push(zone)
+                return `zone-${addedZones.length}`
+              },
+              removeZone() {},
+            })
+          },
+        }),
+      }
+
+      ;(manager as any).syncDiffPresentationDecorations()
+
+      expect(classList.contains('stream-monaco-diff-inline-native-ready')).toBe(false)
+      expect(classList.contains('stream-monaco-diff-native-stale')).toBe(true)
+      expect(addedZones).toHaveLength(2)
+      expect(addedZones[0].marginDomNode.className).toBe(
+        'stream-monaco-fallback-inline-delete-margin',
+      )
     }
     finally {
       ;(globalThis as any).document = originalDocument


### PR DESCRIPTION
## Summary
- require inline deleted view zones and margin zones to be paired before marking inline native diff presentation ready
- keep fallback inline deleted zones active when only part of a multi-hunk delete has native margins
- align diff gutter/line-number fill behavior with the markstream handoff expectations

## Verification
- pnpm test
- pnpm lint
- pnpm build
- pnpm exec tsc --noEmit --incremental false
- pnpm smoke:diff
- pnpm smoke:height-stability
- PORT=5191 pnpm validate:diff-inline
- git diff --check

## Notes
- validate:diff-gutter currently asserts the older symmetric gutter model and fails against the new diffs.com-style gutter spacing; it is not part of CI.