### PR TITLE
fix: preserve theme during Monaco registration

### DIFF
--- a/src/index.base.ts
+++ b/src/index.base.ts
@@ -245,7 +245,7 @@ function useMonaco(monacoOptions: MonacoOptions = {}): UseMonacoReturn {
       return
     }
 
-    await registerMonacoThemes(themes, languages).catch(() => undefined)
+    await registerMonacoThemes(themes, languages, themeName).catch(() => undefined)
 
     if (token !== globalThemeRequestSeq) {
       return
@@ -260,6 +260,7 @@ function useMonaco(monacoOptions: MonacoOptions = {}): UseMonacoReturn {
         const maybeHighlighter = await registerMonacoThemes(
           extended as any,
           languages,
+          themeName,
         )
         await tryLoadAndSetShikiTheme(maybeHighlighter, themeName).catch(
           () => undefined,
@@ -286,7 +287,7 @@ function useMonaco(monacoOptions: MonacoOptions = {}): UseMonacoReturn {
     }
     catch {
       try {
-        const maybeHighlighter = await registerMonacoThemes(themes, languages)
+        const maybeHighlighter = await registerMonacoThemes(themes, languages, themeName)
         if (token !== globalThemeRequestSeq) {
           return
         }
@@ -356,7 +357,7 @@ function useMonaco(monacoOptions: MonacoOptions = {}): UseMonacoReturn {
     const list = availableNames.includes(themeName)
       ? themes
       : (themes.concat(themeName) as any)
-    await registerMonacoThemes(list as any, requestedLanguages)
+    await registerMonacoThemes(list as any, requestedLanguages, themeName)
   }
 
   function resolveRequestedThemeName() {

--- a/src/utils/registerMonacoThemes.ts
+++ b/src/utils/registerMonacoThemes.ts
@@ -115,6 +115,7 @@ let themeRegisterPromise: Promise<import('../type').ShikiHighlighter | null> | n
 // Serialize registrations to avoid races where multiple calls patch Monaco's
 // global `editor.setTheme` with different highlighters in an interleaved order.
 let registrationQueue: Promise<unknown> = Promise.resolve()
+let preferredMonacoThemeName: string | null = null
 function enqueueRegistration<T>(task: () => Promise<T>): Promise<T> {
   const next = registrationQueue.then(task, task)
   // keep queue alive even if a task rejects
@@ -472,6 +473,7 @@ export function clearHighlighterCache() {
   completedLanguages.clear()
   pendingRegistrations.clear()
   lastRegisteredHighlighter = null
+  preferredMonacoThemeName = null
   registrationGeneration++
 }
 
@@ -573,7 +575,20 @@ export { getOrCreateHighlighter }
 export function registerMonacoThemes(
   themes: (ThemeInput | string | SpecialTheme)[],
   languages: string[],
+  preferredThemeName?: string,
 ): Promise<import('../type').ShikiHighlighter | null> {
+  if (preferredThemeName)
+    preferredMonacoThemeName = preferredThemeName
+
+  const restorePreferredTheme = () => {
+    if (!preferredMonacoThemeName)
+      return
+    try {
+      monaco.editor.setTheme(preferredMonacoThemeName)
+    }
+    catch {}
+  }
+
   const requestedThemeKeys = new Set(themes.map(themeKey))
   const requestedLanguages = new Set(languages)
 
@@ -586,6 +601,7 @@ export function registerMonacoThemes(
       requestedLanguages,
     )
   ) {
+    restorePreferredTheme()
     return Promise.resolve(lastRegisteredHighlighter)
   }
 
@@ -598,6 +614,7 @@ export function registerMonacoThemes(
         requestedLanguages,
       )
     ) {
+      restorePreferredTheme()
       return pending.promise
     }
   }
@@ -714,6 +731,10 @@ export function registerMonacoThemes(
 
         const patchMonacoStartedAt = nowMs()
         shikiToMonaco(maybeInstrumentHighlighterGrammar(highlighter), monacoProxy)
+        // @shikijs/monaco applies the first loaded theme while installing its
+        // hooks. Restore the caller's current global theme in the same task so
+        // the temporary theme cannot reach a browser paint.
+        restorePreferredTheme()
         patchMonacoMs = nowMs() - patchMonacoStartedAt
         patchedMonaco = true
         lastPatchedHighlighter = highlighter

--- a/test/registerMonacoThemes.mutation.test.ts
+++ b/test/registerMonacoThemes.mutation.test.ts
@@ -1,6 +1,44 @@
 import { describe, expect, it, vi } from 'vitest'
 
 describe('registerMonacoThemes', () => {
+  it('restores the requested theme synchronously after Shiki patches Monaco', async () => {
+    vi.resetModules()
+
+    const setTheme = vi.fn()
+    const createHighlighter = vi.fn(async () => ({
+      getLoadedThemes: () => ['andromeeda', 'vitesse-dark'],
+      getLoadedLanguages: () => [],
+      getTheme: vi.fn(),
+      setTheme: vi.fn(() => ({ colorMap: [] })),
+    }))
+    const shikiToMonaco = vi.fn((_highlighter, monacoProxy) => {
+      monacoProxy.editor.setTheme('andromeeda')
+    })
+    vi.doMock('shiki', () => ({ createHighlighter }))
+    vi.doMock('@shikijs/monaco', () => ({ shikiToMonaco }))
+    vi.doMock('../src/monaco-shim', () => {
+      const editor = { defineTheme: vi.fn(), setTheme, create: vi.fn() }
+      const languages = {
+        getLanguages: () => [],
+        register: vi.fn(),
+        setTokensProvider: vi.fn(() => ({ dispose() {} })),
+      }
+      return { default: { editor, languages }, editor, languages, Range: class {} }
+    })
+
+    const { registerMonacoThemes } = await import('../src/utils/registerMonacoThemes')
+    await registerMonacoThemes(
+      ['andromeeda', 'vitesse-dark'],
+      ['plaintext'],
+      'vitesse-dark',
+    )
+
+    expect(setTheme.mock.calls).toEqual([
+      ['andromeeda'],
+      ['vitesse-dark'],
+    ])
+  })
+
   it('reuses an in-flight superset registration and skips completed coverage', async () => {
     vi.resetModules()
 


### PR DESCRIPTION
## Summary
- preserve the latest requested Monaco theme while Shiki patches language providers
- restore the requested theme before registration yields to browser paint
- cover the andromeeda-to-vitesse-dark regression

## Verification
- pnpm lint
- pnpm typecheck
- pnpm exec vitest --run (157 tests)
- Nuxt playground frame sampling: no intermediate theme background